### PR TITLE
ctrl+click metaKey+click new non-active tab

### DIFF
--- a/ntp.js
+++ b/ntp.js
@@ -247,7 +247,7 @@ xhr(chrome.extension.getURL("/consts/default_settings.json"), function(res) {
 
         function openIconURL(iconElement, e) {
             if (!document.querySelector("#apps-editor-container.opened")) {
-                if (e.button == 1) {
+                if (e.button == 1 || e.ctrlKey == true || e.metaKey == true) {
                     chrome.tabs.create({ url: iconElement.dataset.url , active: false });
                 } else {
                     chrome.tabs.getCurrent(function(r) {


### PR DESCRIPTION
Sorry to be a pain, I should have thought about this when I initially did the edit.

Allows for users to Control + Click and Metakey + click (⌘ click) open in a new non active tab. Mostly for laptop users.


Kindest Regards,
Andrew