### PR TITLE
event listener changes

### DIFF
--- a/ntp.js
+++ b/ntp.js
@@ -246,7 +246,6 @@ xhr(chrome.extension.getURL("/consts/default_settings.json"), function(res) {
         document.getElementsByTagName("head")[0].appendChild(style);
 
         function openIconURL(iconElement, e) {
-            console.log(e);
             if (!document.querySelector("#apps-editor-container.opened")) {
                 if (e.button == 1 || e.ctrlKey == true || e.metaKey == true) {
                     chrome.tabs.create({ url: iconElement.dataset.url , active: false });

--- a/ntp.js
+++ b/ntp.js
@@ -246,6 +246,7 @@ xhr(chrome.extension.getURL("/consts/default_settings.json"), function(res) {
         document.getElementsByTagName("head")[0].appendChild(style);
 
         function openIconURL(iconElement, e) {
+            console.log(e);
             if (!document.querySelector("#apps-editor-container.opened")) {
                 if (e.button == 1 || e.ctrlKey == true || e.metaKey == true) {
                     chrome.tabs.create({ url: iconElement.dataset.url , active: false });
@@ -286,6 +287,13 @@ xhr(chrome.extension.getURL("/consts/default_settings.json"), function(res) {
         for (i = 0; i < slotCount; i++) {
             var thisApp = document.createElement("div");
             thisApp.classList.add("app");
+
+            //middle click moved from 'click' event to 'auxclick' event between chrome versions 52 and 55
+            thisApp.addEventListener("auxclick", function (e) {
+              if(e.button === 1){ //middle click only, not right click.
+                openIconURL(this, e);
+              }
+            });
 
             thisApp.addEventListener("click", function (e) {
                 openIconURL(this, e);


### PR DESCRIPTION
Good Evening,

Due to [chromium issue 255](https://bugs.chromium.org/p/chromium/issues/detail?id=255), the 'click' event was changed to only the primary mouse button, consequently middle clicking was no longer working in this extension.

In chrome 55, a new event listener [auxclick](https://developers.google.com/web/updates/2016/10/auxclick) was introduced to allow such functionality.

This update incorporates this change, and returns the desired functionality of middle click.